### PR TITLE
FIX : menu left class naming conflict

### DIFF
--- a/class/actions_supportatm.class.php
+++ b/class/actions_supportatm.class.php
@@ -85,8 +85,8 @@ class Actionssupportatm
             $url_email = "mailto:support@atm-consulting.fr?subject=" . urlencode($title) . "&body=" . urlencode($info);
 
             ?>
-            <div class="vmenu">
-                <div id="blockvmenuatm" class="blockvmenubookmarks">
+            <div class="vmenuatm">
+                <div id="blockvmenuatm" class="blockvmenubookmarks" style="margin-left: 6px">
                     <div class="menu_titre">
                         <table class="nobordernopadding" summary="bookmarkstable" width="100%">
                             <tr>


### PR DESCRIPTION
# FIX

La classe du menu left de Dolibarr se nomme vmenu.
Le même nom de classe était utilisé par supportatm ce qui provoquait un décalage de la structure CSS sur certains onglets des card produits/service.